### PR TITLE
Patch Classes.getAllInterfaces to return predictable array

### DIFF
--- a/src/main/java/io/opentracing/contrib/common/Classes.java
+++ b/src/main/java/io/opentracing/contrib/common/Classes.java
@@ -18,6 +18,7 @@ package io.opentracing.contrib.common;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 
 public final class Classes {
   /**
@@ -59,7 +60,7 @@ public final class Classes {
         continue;
 
       if (set == null)
-        set = new HashSet<>(4);
+        set = new LinkedHashSet<>(4);
 
       for (final Class<?> iface : ifaces)
         recurse(iface, set);

--- a/src/test/java/io/opentracing/contrib/common/ClassesTest.java
+++ b/src/test/java/io/opentracing/contrib/common/ClassesTest.java
@@ -23,8 +23,6 @@ import java.util.List;
 
 import org.junit.Test;
 
-import io.opentracing.contrib.common.Classes;
-
 @SuppressWarnings("all")
 public class ClassesTest {
   private static final Comparator<Class<?>> comparator = new Comparator<Class<?>>() {
@@ -36,8 +34,6 @@ public class ClassesTest {
 
   private static void testGetAllInterfaces(final Object obj, final Class<?> ... expecteds) {
     final Class<?>[] ifaces = Classes.getAllInterfaces(obj.getClass());
-    Arrays.sort(ifaces, comparator);
-    Arrays.sort(expecteds, comparator);
     assertEquals(Arrays.toString(ifaces), Arrays.toString(expecteds));
     final List<Class<?>> list = Arrays.asList(ifaces);
     for (final Class<?> expected : expecteds)
@@ -114,12 +110,12 @@ public class ClassesTest {
 
   @Test
   public void testB() {
-    testGetAllInterfaces(b, A.class, B.class);
+    testGetAllInterfaces(b, B.class, A.class);
   }
 
   @Test
   public void testC() {
-    testGetAllInterfaces(c, A.class, B.class, C.class);
+    testGetAllInterfaces(c, C.class, B.class, A.class);
   }
 
   @Test
@@ -129,12 +125,12 @@ public class ClassesTest {
 
   @Test
   public void testFoo() {
-    testGetAllInterfaces(foo, A.class, B.class, C.class, D.class);
+    testGetAllInterfaces(foo, B.class, A.class, C.class, D.class);
   }
 
   @Test
   public void testBar() {
-    testGetAllInterfaces(bar, A.class, B.class, C.class, D.class);
+    testGetAllInterfaces(bar, C.class, B.class, A.class, D.class);
   }
 
   @Test

--- a/src/test/java/io/opentracing/contrib/common/WrapperProxyTest.java
+++ b/src/test/java/io/opentracing/contrib/common/WrapperProxyTest.java
@@ -20,10 +20,6 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 
-import io.opentracing.contrib.common.WrapperProxy;
-import io.opentracing.contrib.common.ClassesTest.A;
-import io.opentracing.contrib.common.ClassesTest.B;
-
 @SuppressWarnings("all")
 public class WrapperProxyTest {
   @Test


### PR DESCRIPTION
When doing native image we need to create the dynamic proxy configuration, as the current code uses a HashSet it does not guarantee order, thus making us add all possible permutation of the classes being used.
I've changed it to a LinkedHashSet so the order is predictable and we can easily configure GraalVM for the Dynamic Proxy.

Related to https://github.com/opentracing-contrib/java-jdbc/issues/116 